### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ export const setPathValue = (layer, path, value) => {
         layer[pathSection] = value
       }
 
-      layer = layer[pathSection] = layer[pathSection] || {}
+      layer = layer[pathSection] = !isPrototypePolluted(pathSection) && layer[pathSection] || {}
       return layer
     }, layer)
 }
@@ -23,3 +23,5 @@ export const expandKeys = (obj) => {
       return obj
     }, obj)
 }
+
+const isPrototypePolluted = (key) => ['__proto__', 'constructor', 'prototype'].includes(key)


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/expand-keys/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/expand-keys/1/README.md

### User Comments:

### :bar_chart: Metadata *

`expand-keys` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-expand-keys 

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var {expandKeys} = require("expand-keys")
console.log("Before : " + {}.polluted);
expandKeys({"__proto__.polluted": "Yes! Its Polluted"})
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i expand-keys # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/102844880-59c3f480-4432-11eb-8184-5dfd83c13f8d.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
